### PR TITLE
Add functionality to find user by samAccountName profile attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ docker-compose up -d
 #### API Permissions
 
 To follow security best practices, I recommend using the least privileged account permissions possible. To make this program work with Okta, a **Help Desk Administrator** level account is required. It is not recommended that you use an API key tied to a superadmin or org admin.
+
+#### Using `samAccountName` to Find a User
+
+By default, the server will use the Okta username to locate the user record, however some systems use `samAccountName` as the username identifier. To locate user records in Okta by the `samAccountName` attribute, add the following to your `run.sh`:
+
+```shell
+export OKTA_USE_SAMACCOUNTNAME=true
+```

--- a/okta.py
+++ b/okta.py
@@ -1,7 +1,7 @@
 import logging
 
 from requests import Session
-from requests.compat import urljoin
+from requests.compat import urljoin, urlencode, quote
 from requests.exceptions import HTTPError
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -57,6 +57,14 @@ class OktaAPI(object):
         page = self._get(url)
 
         return page["id"]
+
+    def get_user_by_samaccountname(self, username):
+        data = urlencode({'search': f"profile.samaccountname eq \"{username}\""}, quote_via=quote)
+        url = urljoin(self.base_url, f"api/v1/users?{data}")
+
+        page = self._get(url)
+
+        return page[0]["id"]
 
     def get_user_push_factor(self, user_id):
         url = urljoin(self.base_url, 'api/v1/users/{}/factors'.format(user_id))

--- a/okta.py
+++ b/okta.py
@@ -59,7 +59,7 @@ class OktaAPI(object):
         return page["id"]
 
     def get_user_by_samaccountname(self, username):
-        data = urlencode({'search': f"profile.samaccountname eq \"{username}\""}, quote_via=quote)
+        data = urlencode({'search': f"profile.samAccountName eq \"{username}\""}, quote_via=quote)
         url = urljoin(self.base_url, f"api/v1/users?{data}")
 
         page = self._get(url)

--- a/server.py
+++ b/server.py
@@ -35,7 +35,10 @@ class RadiusServer(Server):
         reply.code = AccessReject
 
         try:
-            u = self.okta.get_user_id(user_name)
+            if os.environ.get('OKTA_USE_SAMACCOUNTNAME'):
+                u = self.okta.get_user_by_samaccountname(user_name)
+            else:
+                u = self.okta.get_user_id(user_name)
             f = self.okta.get_user_push_factor(u)
             if f is not None:
                 push = self.okta.push_verify(u, f["id"])

--- a/tests.py
+++ b/tests.py
@@ -355,7 +355,7 @@ def mocked_sessions(*args, **kwargs):
                 }
             }
         },
-        'https://fake/api/v1/users?search=profile.samaccountname%20eq%20%22username%22':
+        'https://fake/api/v1/users?search=profile.samAccountName%20eq%20%22username%22':
             [
                 {
                     "id": "00ub0oNGTSWTBKOLGLNR",
@@ -443,7 +443,7 @@ class TestOkta(unittest.TestCase):
         self.assertEqual(r, '00ub0oNGTSWTBKOLGLNR')
 
         mock_get.assert_called_once_with('https://fake/api/v1/users?search=profile'
-                                         '.samaccountname%20eq%20%22username%22', params=None)
+                                         '.samAccountName%20eq%20%22username%22', params=None)
 
 
 class TestRadius(unittest.TestCase):


### PR DESCRIPTION
Adding an environment variable `OKTA_USE_SAMACCOUNTNAME` will allow searching for a user record based on the `samAccountName` profile attribute.